### PR TITLE
Add Blender ball example

### DIFF
--- a/examples/01_blender_ball/0_generate_frames.py
+++ b/examples/01_blender_ball/0_generate_frames.py
@@ -1,0 +1,63 @@
+import bpy
+import os
+
+# Configure scene
+scene = bpy.context.scene
+scene.frame_start = 1
+scene.frame_end = 30
+scene.render.fps = 30
+scene.render.resolution_x = 640
+scene.render.resolution_y = 480
+scene.render.image_settings.file_format = 'PNG'
+
+# Remove default objects
+bpy.ops.object.select_all(action='SELECT')
+bpy.ops.object.delete(use_global=False)
+
+# Create black cube walls (1m cube)
+bpy.ops.mesh.primitive_cube_add(size=1, location=(0.5, 0.5, -0.5))
+cube = bpy.context.object
+mat = bpy.data.materials.new(name="Black")
+mat.use_nodes = True
+bsdf = mat.node_tree.nodes["Principled BSDF"]
+bsdf.inputs["Base Color"].default_value = (0, 0, 0, 1)
+bsdf.inputs["Roughness"].default_value = 1
+cube.data.materials.append(mat)
+# Flip normals so the cube is visible from inside
+bpy.ops.object.mode_set(mode='EDIT')
+bpy.ops.mesh.normals_make_consistent(inside=True)
+bpy.ops.object.mode_set(mode='OBJECT')
+
+# Empty at the center for camera tracking
+bpy.ops.object.empty_add(location=(0.5, 0.5, -0.5))
+center = bpy.context.object
+
+# Create sphere
+bpy.ops.mesh.primitive_uv_sphere_add(radius=0.05, location=(0, 0.5, -0.3))
+sphere = bpy.context.object
+sphere.keyframe_insert(data_path="location", frame=1)
+sphere.location = (1, 0.5, -0.3)
+sphere.keyframe_insert(data_path="location", frame=30)
+
+# Add camera
+bpy.ops.object.camera_add(location=(0.5, 0.5, -1))
+cam = bpy.context.object
+track = cam.constraints.new(type='TRACK_TO')
+track.target = center
+track.track_axis = 'TRACK_NEGATIVE_Z'
+track.up_axis = 'UP_Y'
+
+# Light 0.3m above the camera
+bpy.ops.object.light_add(type='POINT', location=(0.5, 0.8, -1))
+light = bpy.context.object
+light.data.energy = 1000
+
+# Directory for rendered frames
+frames_dir = os.path.join(os.path.dirname(bpy.data.filepath), "frames")
+os.makedirs(frames_dir, exist_ok=True)
+
+# Render all frames
+for frame in range(scene.frame_start, scene.frame_end + 1):
+    scene.frame_set(frame)
+    scene.render.filepath = os.path.join(frames_dir, f"frame_{frame:04d}.png")
+    bpy.ops.render.render(write_still=True)

--- a/examples/01_blender_ball/1_frames_to_events.py
+++ b/examples/01_blender_ball/1_frames_to_events.py
@@ -1,0 +1,52 @@
+"""Generate event data from rendered frames using IEBCS."""
+import os
+import cv2
+import numpy as np
+import sys
+
+sys.path.append("../../src")
+from dvs_sensor import DvsSensor
+from event_buffer import EventBuffer
+
+FRAME_DIR = "frames"
+OUTPUT_DIR = "outputs"
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+frame_files = sorted(
+    [os.path.join(FRAME_DIR, f) for f in os.listdir(FRAME_DIR) if f.endswith(".png")]
+)
+if not frame_files:
+    raise RuntimeError("No frames found. Run 0_generate_frames.py in Blender first.")
+
+# Read first frame to initialise the sensor
+im = cv2.imread(frame_files[0], cv2.IMREAD_GRAYSCALE)
+height, width = im.shape
+
+th_pos = 0.4
+th_neg = 0.4
+th_noise = 0.01
+lat = 100
+tau = 40
+jit = 10
+bgnp = 0.1
+bgnn = 0.01
+ref = 100
+
+sensor = DvsSensor("BallSensor")
+sensor.initCamera(width, height, lat=lat, jit=jit, ref=ref, tau=tau,
+                   th_pos=th_pos, th_neg=th_neg, th_noise=th_noise,
+                   bgnp=bgnp, bgnn=bgnn)
+sensor.init_bgn_hist("../../data/noise_pos_161lux.npy", "../../data/noise_neg_161lux.npy")
+
+sensor.init_image(im.astype(np.float32) / 255.0 * 1e4)
+
+dt = int(1e6 / 30)  # microseconds per frame at 30 fps
+buffer = EventBuffer(1)
+
+for f in frame_files[1:]:
+    im = cv2.imread(f, cv2.IMREAD_GRAYSCALE)
+    im = im.astype(np.float32) / 255.0 * 1e4
+    events = sensor.update(im, dt)
+    buffer.increase_ev(events)
+
+buffer.write(os.path.join(OUTPUT_DIR, "ball_events.dat"), width=width, height=height)

--- a/examples/01_blender_ball/README.md
+++ b/examples/01_blender_ball/README.md
@@ -1,0 +1,26 @@
+# Blender Ball Example
+
+This example demonstrates how to generate IEBCS event data from a simple Blender
+animation. A black 1x1x1 m room is created and a small ball moves from
+`(0, 0.5, -0.3)` to `(1, 0.5, -0.3)`. The camera is placed at `(0.5, 0.5, -1)`
+looking at the centre of the room and a point light is positioned `0.3` m above
+the camera.
+
+1. **Render frames with Blender**
+
+   ```bash
+   blender -b -P 0_generate_frames.py
+   ```
+
+   PNG images will be stored in the `frames/` directory.
+
+2. **Convert frames to events**
+
+   Run the conversion script using Python:
+
+   ```bash
+   python 1_frames_to_events.py
+   ```
+
+   The output event file `ball_events.dat` will be written to the `outputs/`
+   directory.


### PR DESCRIPTION
## Summary
- add example to generate frames using Blender
- convert Blender frames to IEBCS event data
- document how to run the Blender example

## Testing
- `python -m py_compile examples/01_blender_ball/0_generate_frames.py examples/01_blender_ball/1_frames_to_events.py`

------
https://chatgpt.com/codex/tasks/task_e_6847730cbce08323a9804f40dc2255f9