### PR TITLE
Fix Blender ball camera placement

### DIFF
--- a/examples/01_blender_ball/0_generate_frames.py
+++ b/examples/01_blender_ball/0_generate_frames.py
@@ -39,8 +39,8 @@ sphere.keyframe_insert(data_path="location", frame=1)
 sphere.location = (1, 0.5, -0.3)
 sphere.keyframe_insert(data_path="location", frame=30)
 
-# Add camera
-bpy.ops.object.camera_add(location=(0.5, 0.5, -1))
+# Add camera inside the cube
+bpy.ops.object.camera_add(location=(0.5, 0.5, -0.8))
 cam = bpy.context.object
 scene.camera = cam
 track = cam.constraints.new(type='TRACK_TO')
@@ -48,8 +48,8 @@ track.target = center
 track.track_axis = 'TRACK_NEGATIVE_Z'
 track.up_axis = 'UP_Y'
 
-# Light 0.3m above the camera
-bpy.ops.object.light_add(type='POINT', location=(0.5, 0.8, -1))
+# Light 0.3m above the camera inside the cube
+bpy.ops.object.light_add(type='POINT', location=(0.5, 0.8, -0.8))
 light = bpy.context.object
 light.data.energy = 1000
 

--- a/examples/01_blender_ball/README.md
+++ b/examples/01_blender_ball/README.md
@@ -2,9 +2,9 @@
 
 This example demonstrates how to generate IEBCS event data from a simple Blender
 animation. A black 1x1x1 m room is created and a small ball moves from
-`(0, 0.5, -0.3)` to `(1, 0.5, -0.3)`. The camera is placed at `(0.5, 0.5, -1)`
-looking at the centre of the room and a point light is positioned `0.3` m above
-the camera.
+`(0, 0.5, -0.3)` to `(1, 0.5, -0.3)`. The camera is placed at `(0.5, 0.5, -0.8)`
+inside the cube, looking at the centre of the room and a point light is
+positioned `0.3` m above the camera.
 
 1. **Render frames with Blender**
 


### PR DESCRIPTION
## Summary
- place camera and light inside the cube in the Blender example
- update README with corrected camera coordinates

## Testing
- `pre-commit` *(fails: `pre-commit` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684775c4f3548323aa2066526f14a04b