### PR TITLE
Make ball speed time-based

### DIFF
--- a/examples/01_blender_ball/0_generate_frames.py
+++ b/examples/01_blender_ball/0_generate_frames.py
@@ -1,13 +1,40 @@
 import bpy
 import os
+import math
+
+# ----------------------------
+# Configuration parameters
+# ----------------------------
+
+# Output frame rate (frames per second)
+FPS = 15
+
+# Output resolution
+RESOLUTION_X = 1280
+RESOLUTION_Y = 720
+
+# Ball motion parameters
+# Starting and ending positions in metres
+BALL_START = (0.0, 0.5, -0.3)
+BALL_END = (1.0, 0.5, -0.3)
+# Constant ball speed in metres per second
+BALL_SPEED = 0.5
 
 # Configure scene
 scene = bpy.context.scene
 scene.frame_start = 1
-scene.frame_end = 30
-scene.render.fps = 15
-scene.render.resolution_x = 1280
-scene.render.resolution_y = 720
+
+# Duration of the ball motion (computed from speed and distance)
+distance = math.sqrt(sum((e - s) ** 2 for s, e in zip(BALL_START, BALL_END)))
+duration = distance / BALL_SPEED
+
+# Total frames of the animation determined by duration and FPS
+total_frames = int(round(duration * FPS))
+scene.frame_end = scene.frame_start + total_frames - 1
+
+scene.render.fps = FPS
+scene.render.resolution_x = RESOLUTION_X
+scene.render.resolution_y = RESOLUTION_Y
 scene.render.image_settings.file_format = 'PNG'
 
 # Remove default objects
@@ -33,11 +60,11 @@ bpy.ops.object.empty_add(location=(0.5, 0.5, -0.5))
 center = bpy.context.object
 
 # Create sphere
-bpy.ops.mesh.primitive_uv_sphere_add(radius=0.05, location=(0, 0.5, -0.3))
+bpy.ops.mesh.primitive_uv_sphere_add(radius=0.05, location=BALL_START)
 sphere = bpy.context.object
-sphere.keyframe_insert(data_path="location", frame=1)
-sphere.location = (1, 0.5, -0.3)
-sphere.keyframe_insert(data_path="location", frame=30)
+sphere.keyframe_insert(data_path="location", frame=scene.frame_start)
+sphere.location = BALL_END
+sphere.keyframe_insert(data_path="location", frame=scene.frame_end)
 
 # Add camera inside the cube
 bpy.ops.object.camera_add(location=(0.5, 0.5, -0.8))

--- a/examples/01_blender_ball/README.md
+++ b/examples/01_blender_ball/README.md
@@ -6,6 +6,12 @@ animation. A black 1x1x1 m room is created and a small ball moves from
 inside the cube, looking at the centre of the room and a point light is
 positioned `0.3` m above the camera.
 
+The script `0_generate_frames.py` allows changing the output FPS and the
+ball's motion using a set of variables defined at the top of the file.  The
+number of frames is automatically computed from the specified speed and the
+distance the ball travels, so the animation duration remains the same when the
+FPS is changed.
+
 1. **Render frames with Blender**
 
    ```bash
@@ -24,3 +30,19 @@ positioned `0.3` m above the camera.
 
    The output event file `ball_events.dat` will be written to the `outputs/`
    directory.
+
+## Customising the animation
+
+The parameters controlling the ball motion and the output FPS are defined at
+the top of `0_generate_frames.py`:
+
+```python
+FPS = 15                     # Output frame rate
+BALL_START = (0.0, 0.5, -0.3)  # Start position
+BALL_END = (1.0, 0.5, -0.3)    # End position
+BALL_SPEED = 0.5             # Speed in metres per second
+```
+
+Adjust these values to change the resolution, the path or the speed.  The script
+calculates how many frames are required based on the chosen FPS and speed so the
+ball appears for the same amount of real time regardless of the FPS value.


### PR DESCRIPTION
## Summary
- allow configuring FPS, resolution and ball speed in `0_generate_frames.py`
- compute animation duration from ball speed so FPS changes don't alter run-time
- document new parameters in the README

## Testing
- `python -m py_compile examples/01_blender_ball/0_generate_frames.py`

------
https://chatgpt.com/codex/tasks/task_e_6847abf46f748323bc80a7a2a5b7a4d2