### PR TITLE
Add per-event object vs shadow labelling example

### DIFF
--- a/examples/04_ball/README.md
+++ b/examples/04_ball/README.md
@@ -8,4 +8,9 @@ Run the script with Blender in background mode:
 blender -b -P generate.py
 ```
 
-Output video and event files will be created in `./output_ball`.
+The script now renders two passes per frame: one with only the sphere and another
+containing only its shadow. Event streams are generated separately for each
+pass. Object events are saved to `ball_object.dat` and shadow events to
+`ball_shadow.dat` in the `./output_ball` directory. A normal video with shadows
+is also produced.
+

--- a/examples/04_ball/generate.py
+++ b/examples/04_ball/generate.py
@@ -1,6 +1,5 @@
 import bpy
 import cv2
-import math
 import os
 import sys
 from mathutils import Vector
@@ -24,9 +23,11 @@ start_pos = Vector((-5.0, 0.0, 0.0))
 end_pos   = Vector((5.0, 0.0, 0.0))
 delta = (end_pos - start_pos) / (frames - 1)
 
+dat_path_obj = os.path.join(base_path, "ball_object.dat")
+dat_path_shadow = os.path.join(base_path, "ball_shadow.dat")
+tmp_obj_path = os.path.join(base_path, "tmp_object.png")
+tmp_shadow_path = os.path.join(base_path, "tmp_shadow.png")
 video_path = os.path.join(base_path, "ball.avi")
-dat_path = os.path.join(base_path, "ball.dat")
-tmp_image_path = os.path.join(base_path, "tmp_ball.png")
 
 # Clean scene
 bpy.ops.object.select_all(action='SELECT')
@@ -66,7 +67,7 @@ light_obj.location = cam.location + Vector((0, 0, 2))
 
 # Render settings
 scene = bpy.context.scene
-scene.render.engine = 'BLENDER_EEVEE'
+scene.render.engine = 'CYCLES'
 scene.render.resolution_x = sensor_width
 scene.render.resolution_y = sensor_height
 scene.render.image_settings.file_format = 'PNG'
@@ -75,45 +76,91 @@ scene.frame_end = frames - 1
 scene.cycles.device = 'GPU'
 
 # Initialise sensor
-sensor = DvsSensor("BallSensor")
-sensor.initCamera(sensor_width, sensor_height,
-                  lat=100, jit=100, ref=100, tau=300,
-                  th_pos=0.15, th_neg=0.15, th_noise=0.05,
-                  bgnp=0.0001, bgnn=0.0001)
+sensor_obj = DvsSensor("ObjectSensor")
+sensor_obj.initCamera(sensor_width, sensor_height,
+                      lat=100, jit=100, ref=100, tau=300,
+                      th_pos=0.15, th_neg=0.15, th_noise=0.05,
+                      bgnp=0.0001, bgnn=0.0001)
 
-buffer = EventBuffer(0)
+sensor_shadow = DvsSensor("ShadowSensor")
+sensor_shadow.initCamera(sensor_width, sensor_height,
+                         lat=100, jit=100, ref=100, tau=300,
+                         th_pos=0.15, th_neg=0.15, th_noise=0.05,
+                         bgnp=0.0001, bgnn=0.0001)
+
+buffer_obj = EventBuffer(0)
+buffer_shadow = EventBuffer(0)
 
 # Animation loop
 for frame in range(frames):
     scene.frame_set(frame)
     ball.location = start_pos + delta * frame
     ball.keyframe_insert(data_path="location")
-    scene.render.filepath = tmp_image_path
+
+    # ----------------------
+    # Object-only rendering
+    # ----------------------
+    ball.cycles_visibility.shadow = False
+    ball.cycles_visibility.camera = True
+    backdrop.cycles.is_shadow_catcher = False
+    scene.render.film_transparent = False
+    scene.render.filepath = tmp_obj_path
     bpy.ops.render.render(write_still=True)
-    color = cv2.imread(tmp_image_path)
+    color = cv2.imread(tmp_obj_path)
     if color is None:
-        raise RuntimeError(f"Failed to load rendered image: {tmp_image_path}")
-    img = cv2.cvtColor(color, cv2.COLOR_BGR2GRAY).astype(float) / 255.0 * 1e4
+        raise RuntimeError(f"Failed to load rendered image: {tmp_obj_path}")
+    img_obj = cv2.cvtColor(color, cv2.COLOR_BGR2GRAY).astype(float) / 255.0 * 1e4
 
     if frame == 0:
-        sensor.init_image(img)
+        sensor_obj.init_image(img_obj)
     else:
-        events = sensor.update(img, 1000)
-        buffer.increase_ev(events)
+        events = sensor_obj.update(img_obj, 1000)
+        buffer_obj.increase_ev(events)
+
+    # ----------------------
+    # Shadow-only rendering
+    # ----------------------
+    ball.cycles_visibility.shadow = True
+    ball.cycles_visibility.camera = False
+    backdrop.cycles.is_shadow_catcher = True
+    scene.render.film_transparent = True
+    scene.render.filepath = tmp_shadow_path
+    bpy.ops.render.render(write_still=True)
+    color = cv2.imread(tmp_shadow_path)
+    if color is None:
+        raise RuntimeError(f"Failed to load rendered image: {tmp_shadow_path}")
+    img_shadow = cv2.cvtColor(color, cv2.COLOR_BGR2GRAY).astype(float) / 255.0 * 1e4
+
+    if frame == 0:
+        sensor_shadow.init_image(img_shadow)
+    else:
+        events = sensor_shadow.update(img_shadow, 1000)
+        buffer_shadow.increase_ev(events)
 
 # Save events
-if buffer.i > 0:
-    buffer.write(dat_path)
-    print(f"Generated event data: {dat_path}")
+if buffer_obj.i > 0:
+    buffer_obj.write(dat_path_obj)
+    print(f"Generated object event data: {dat_path_obj}")
 else:
-    print("No events generated.")
+    print("No object events generated.")
+
+if buffer_shadow.i > 0:
+    buffer_shadow.write(dat_path_shadow)
+    print(f"Generated shadow event data: {dat_path_shadow}")
+else:
+    print("No shadow events generated.")
 
 # Output video
+ball.cycles_visibility.camera = True
+ball.cycles_visibility.shadow = True
+backdrop.cycles.is_shadow_catcher = False
+scene.render.film_transparent = False
 scene.render.image_settings.file_format = 'AVI_JPEG'
 scene.render.fps = 60
 scene.render.filepath = video_path
 bpy.ops.render.render(animation=True)
 print(f"Generated video: {video_path}")
 
-if os.path.exists(tmp_image_path):
-    os.remove(tmp_image_path)
+for p in (tmp_obj_path, tmp_shadow_path):
+    if os.path.exists(p):
+        os.remove(p)


### PR DESCRIPTION
## Summary
- add new two-pass rendering to generate object and shadow events separately
- document the new behaviour

## Testing
- `python -m py_compile examples/04_ball/generate.py`
- `python -m py_compile src/event_buffer.py src/dvs_sensor.py`

------
https://chatgpt.com/codex/tasks/task_e_684bbd5e1cd483239ed0293ae2674362